### PR TITLE
Minor spelling-error

### DIFF
--- a/src/RazorRockstars.WebHost/default.cshtml
+++ b/src/RazorRockstars.WebHost/default.cshtml
@@ -243,7 +243,7 @@
         <li>
             <a href="#optimized-for-dev">Optimized for developer productivity</a>            
             <ul>
-                <li>Great perforance, Optimized for run-time and iteration times</li>        
+                <li>Great performance, Optimized for run-time and iteration times</li>        
                 <li>Parallel compilation of Razor views at startup (in Debug mode)</li>
                 <li>Automatic reload of modified views, layout templates and partials (in Debug mode)</li>
             </ul>


### PR DESCRIPTION
A guy on JabbR noticed you were missing an m in performance in one of the feature descriptions:

_tomasz.kubacki_
@mythz spotted typo 'Great perforance' at http://razor.servicestack.net/#runs-everywhere
